### PR TITLE
Make this usable after installation from npm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Install:
 ##Quickstart:
 Create AnyMesh singleton:
 
-    var AnyMesh = require("AnyMesh");
+    var AnyMesh = require("anymesh");
     var anyMesh = new AnyMesh();
 
 Handle messages received by defining callback function:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "type": "MIT"
     }
     ],
-
+    "main": "lib/AnyMesh.js",
     "description" : "A multi-platform, decentralized, auto-discover and auto-connect mesh networking and messaging API",
     "keywords" : [
       "mesh",


### PR DESCRIPTION
- Add a `main` key in `package.json` so that it's usable from node.js apps
- Fix the README to use the proper package name (`anymesh` rather than `AnyMesh`)
